### PR TITLE
CI: Sign pre-release commits

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -90,13 +90,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create Release or Bugfix branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "factory-x-bot"
-          git config user.email "factory-x-bot@factory-x.org"
+        #- uses: webfactory/ssh-agent@v0.9.0
+        #  with:
+        #    ssh-private-key: ${{ secrets.DEPLOY_KEY }}
       - name: Bump version in maven pom.xml files
         run: |-
           mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
@@ -150,7 +146,7 @@ jobs:
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push new branch
         run: |
-          git remote set-url origin git@github.com:${{ github.repository }}.git
+          #git remote set-url origin git@github.com:${{ github.repository }}.git
           git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
       - name: Create pull request
         if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -32,9 +32,7 @@ on:
       version:
         description: 'The version you want to release. Ref should be either main for latest releases or a tag for bugfixes. '
         required: true
-      committer-mail:
-        description: 'Your e-mail address for committing the pre-release changes. If blank, uses the anonymous <id>+<username>@users.noreply.github.com address'
-        required: false
+
 
 env:
   # One submodule cannot be built (authorization required) so we get the released version of it
@@ -102,10 +100,6 @@ jobs:
           passphrase: ${{ secrets.FX_BOT_GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-      - name: Set up git user
-        run: |
-          git config user.name "carlos-schmidt"
-          git config user.email "18703981+carlos-schmidt@users.noreply.github.com"
       - name: Bump version in maven pom.xml files
         run: |-
           mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
@@ -158,7 +152,7 @@ jobs:
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push new branch
         run: |
-          git remote set-url origin git@github.com:${{ github.repository }}.git
+          #git remote set-url origin git@github.com:${{ github.repository }}.git
           git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
       - name: Create pull request
         if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -32,6 +32,9 @@ on:
       version:
         description: 'The version you want to release. Ref should be either main for latest releases or a tag for bugfixes. '
         required: true
+      committer-mail:
+        description: 'Your e-mail address for committing the pre-release changes. If blank, uses the anonymous <id>+<username>@users.noreply.github.com address'
+        required: false
 
 env:
   # One submodule cannot be built (authorization required) so we get the released version of it
@@ -54,7 +57,6 @@ jobs:
       - id: check-tag
         name: "Check if tag exists"
         run: |-
-
           tag=$(git tag -l ${{ inputs.version }})
 
           if [ ! -z $tag ];
@@ -88,6 +90,14 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - name: Setup git user
+        run: |
+          git config user.name "${{ github.actor }}"
+          email="${{ inputs.email }}"
+          if [ -z "$email" ]; then
+            email="${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          fi
+          git config user.email "$email"
       - name: Create Release or Bugfix branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
         #- uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -92,9 +92,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create Release or Bugfix branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+        #- uses: webfactory/ssh-agent@v0.9.0
+        #  with:
+        #   ssh-private-key: ${{ secrets.DEPLOY_KEY }}
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -92,13 +92,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create Release or Bugfix branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
-        #- uses: webfactory/ssh-agent@v0.9.0
-        #  with:
-        #    ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.FX_BOT_GPG_PRIVKEY }}
+          passphrase: ${{ secrets.FX_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Set up git user
         run: |
-          git config user.name "factory-x-bot"
-          git config user.email "factory-x-bot@factory-x.org"
+          git config user.name "carlos-schmidt"
+          git config user.email "18703981+carlos-schmidt@users.noreply.github.com"
       - name: Bump version in maven pom.xml files
         run: |-
           mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
@@ -147,8 +154,7 @@ jobs:
         id: make-commit
         run: |
           git add .
-          git commit --message "Prepare release ${{ inputs.version }}"
-
+          git commit -S --message "Prepare release ${{ inputs.version }}"
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push new branch
         run: |

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -90,9 +90,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create Release or Bugfix branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
-        #- uses: webfactory/ssh-agent@v0.9.0
-        #  with:
-        #   ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
@@ -152,7 +152,7 @@ jobs:
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push new branch
         run: |
-          #git remote set-url origin git@github.com:${{ github.repository }}.git
+          git remote set-url origin git@github.com:${{ github.repository }}.git
           git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
       - name: Create pull request
         if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -90,19 +90,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: Setup git user
-        run: |
-          git config user.name "${{ github.actor }}"
-          email="${{ inputs.email }}"
-          if [ -z "$email" ]; then
-            email="${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
-          fi
-          git config user.email "$email"
       - name: Create Release or Bugfix branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
         #- uses: webfactory/ssh-agent@v0.9.0
         #  with:
         #    ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Set up git user
+        run: |
+          git config user.name "factory-x-bot"
+          git config user.email "factory-x-bot@factory-x.org"
       - name: Bump version in maven pom.xml files
         run: |-
           mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
@@ -156,7 +152,7 @@ jobs:
           echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Push new branch
         run: |
-          #git remote set-url origin git@github.com:${{ github.repository }}.git
+          git remote set-url origin git@github.com:${{ github.repository }}.git
           git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
       - name: Create pull request
         if: ${{ github.ref_name == 'main' }}


### PR DESCRIPTION
## WHAT

Adds GPG signing to the current CI pipeline ...

## WHY

... to comply with org/repo rulesets

## FURTHER NOTES

See commit history for my verified commit. This is not enabled by default.

https://github.com/carlos-schmidt/fa3st-service/commits/release/0.1.0-cloudevents/