### PR TITLE
Fix(CI): unsigned ci operations, dependencies

### DIFF
--- a/.github/actions/generate-and-check-dependencies/action.yaml
+++ b/.github/actions/generate-and-check-dependencies/action.yaml
@@ -43,7 +43,7 @@ runs:
         mvn dependency:list > dependencies-unclean
         if grep -q "ERROR" dependencies_unclean; then exit 1;  fi
         cat dependencies-unclean | grep -o '[a-zA-Z0-9.-]\+:[a-zA-Z0-9.-]\+:jar:[0-9.]\+' | sed 's/:jar//' | sort | uniq > dependency-list
-        grep -vF 'de.fraunhofer.iosb.ilt.faaast.service' dependency-list
+        sed -i '/de\.fraunhofer\.iosb\.ilt\.faaast\.service/d' dependency-list
         cat dependency-list
 
     - name: Print failure reason

--- a/.github/actions/generate-and-check-dependencies/action.yaml
+++ b/.github/actions/generate-and-check-dependencies/action.yaml
@@ -43,6 +43,7 @@ runs:
         mvn dependency:list > dependencies-unclean
         if grep -q "ERROR" dependencies_unclean; then exit 1;  fi
         cat dependencies-unclean | grep -o '[a-zA-Z0-9.-]\+:[a-zA-Z0-9.-]\+:jar:[0-9.]\+' | sed 's/:jar//' | sort | uniq > dependency-list
+        grep -vF 'de.fraunhofer.iosb.ilt.faaast.service' dependency-list
         cat dependency-list
 
     - name: Print failure reason

--- a/.github/actions/generate-and-check-dependencies/action.yaml
+++ b/.github/actions/generate-and-check-dependencies/action.yaml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         mvn dependency:list > dependencies-unclean
-        if grep -q "ERROR" dependencies_unclean; then exit 1;  fi
+        if grep -q "ERROR" dependencies-unclean; then exit 1;  fi
         cat dependencies-unclean | grep -o '[a-zA-Z0-9.-]\+:[a-zA-Z0-9.-]\+:jar:[0-9.]\+' | sed 's/:jar//' | sort | uniq > dependency-list
         sed -i '/de\.fraunhofer\.iosb\.ilt\.faaast\.service/d' dependency-list
         cat dependency-list

--- a/.github/actions/generate-and-check-dependencies/action.yaml
+++ b/.github/actions/generate-and-check-dependencies/action.yaml
@@ -44,6 +44,7 @@ runs:
         if grep -q "ERROR" dependencies-unclean; then exit 1;  fi
         cat dependencies-unclean | grep -o '[a-zA-Z0-9.-]\+:[a-zA-Z0-9.-]\+:jar:[0-9.]\+' | sed 's/:jar//' | sort | uniq > dependency-list
         sed -i '/de\.fraunhofer\.iosb\.ilt\.faaast\.service/d' dependency-list
+        rm dependencies-unclean
         cat dependency-list
 
     - name: Print failure reason

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -28,16 +28,22 @@ on:
   workflow_dispatch:
   workflow_call:
 
-env:
-  # One submodule cannot be built (authorization required) so we get the released version of it
-  UPSTREAM_LATEST_VERSION: 1.3.0-SNAPSHOT
-
 jobs:
   Bump-Version:
     name: 'Update snapshot version'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.FX_BOT_GPG_PRIVKEY }}
+          passphrase: ${{ secrets.FX_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Set new snapshot version
         shell: bash
         run: |
@@ -59,17 +65,11 @@ jobs:
           SNAPSHOT_VERSION=$VERSION
 
           # Persist the "version" in the pom.xml
-          mvn -B -ntp versions:set -DnewVersion='$SNAPSHOT_VERSION' -DgenerateBackupPoms=false
-          # Fix unbuildable dependencies' versions
-          sed -i "/<artifactId>endpoint-opcua<\/artifactId>/,/<\/dependency>/{ s#<version>[^<]*</version>#<version>$UPSTREAM_LATEST_VERSION</version># }" starter/pom.xml
-          sed -i "/<artifactId>endpoint-opcua<\/artifactId>/,/<\/dependency>/{ s#<version>[^<]*</version>#<version>$UPSTREAM_LATEST_VERSION</version># }" test/pom.xml
-
-          # Prepare git env
-          git config user.name "factory-x-bot"
-          git config user.email "factory-x-bot@factory-x.org"
+          mvn -B -ntp versions:set -DnewVersion="$SNAPSHOT_VERSION" -DgenerateBackupPoms=false
 
           # Commit and push to origin main
           git add .
-          git commit --message "Introduce new snapshot version $SNAPSHOT_VERSION"
+          git commit -S --message "Introduce new snapshot version $SNAPSHOT_VERSION"
 
-          git push
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+          git push origin main

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -35,8 +35,6 @@ on:
 
 
 env:
-  # One submodule cannot be built (authorization required) so we get the released version of it
-  UPSTREAM_LATEST_VERSION: 1.3.0-SNAPSHOT
   REGISTRY: ghcr.io
   ORG: ${{ github.repository_owner }}
   IMAGE: ${{ github.event.repository.name }}
@@ -103,10 +101,6 @@ jobs:
       - name: Bump version in maven pom.xml files
         run: |-
           mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
-      - name: Replace unbuildable local dependency versions with upstream released versions
-        run: |-
-          sed -i "/<artifactId>endpoint-opcua<\/artifactId>/,/<\/dependency>/{ s#<version>[^<]*</version>#<version>$UPSTREAM_LATEST_VERSION</version># }" starter/pom.xml
-          sed -i "/<artifactId>endpoint-opcua<\/artifactId>/,/<\/dependency>/{ s#<version>[^<]*</version>#<version>$UPSTREAM_LATEST_VERSION</version># }" test/pom.xml
       # Docker build & publish
       - name: Update project docs
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,11 +36,10 @@ on:
 
 
 jobs:
-  # Gate
   validation:
-    name: "Check if repository is not fork AND head is release OR base is bugfix"
+    name: "Check if head is release OR base is bugfix"
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'factory-x-contributions/fa3st-service' && (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.ref_name, 'bugfix/')) }}
+    if: ${{ (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.ref_name, 'bugfix/')) }}
     outputs:
       RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
     steps:
@@ -60,21 +59,22 @@ jobs:
     if: needs.validation.outputs.RELEASE_VERSION
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare Git Config
-        shell: bash
-        run: |
-          # Prepare git env
-          git config user.name "factory-x-bot"
-          git config user.email "factory-x-bot@factory-x.org"
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.FX_BOT_GPG_PRIVKEY }}
+          passphrase: ${{ secrets.FX_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
       - name: Create Release Tag
         id: create_release_tag
         shell: bash
         run: |
-          # informative
-          git branch -a
-          git tag
-
-          # Create & push tag
+          git remote set-url origin git@github.com:${{ github.repository }}.git
           git tag ${{ needs.validation.outputs.RELEASE_VERSION }}
           git push origin ${{ needs.validation.outputs.RELEASE_VERSION }}
       - name: Create GitHub Release
@@ -91,14 +91,3 @@ jobs:
     if: github.ref_name == 'main'
     uses: ./.github/workflows/bump-version.yaml
     secrets: inherit
-
-  # Release: Publish specs to GitHub Pages
-#  publish-openapi-to-gh-pages:
-#    name: "Publish OpenAPI UI spec GitHub Pages"
-#    permissions:
-#      contents: write
-#    needs: [ validation ]
-#    uses: ./.github/workflows/publish-openapi-ui.yml
-#    secrets: inherit
-#    with:
-#      version: ${{ needs.validation.outputs.RELEASE_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: |
           git remote set-url origin git@github.com:${{ github.repository }}.git
-          git tag -a ${{ needs.validation.outputs.RELEASE_VERSION }} -m "Release 0.1.1-cloudevents"
+          git tag -a ${{ needs.validation.outputs.RELEASE_VERSION }} -m "Release ${{ needs.validation.outputs.RELEASE_VERSION }}"
           git push origin ${{ needs.validation.outputs.RELEASE_VERSION }}
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: |
           git remote set-url origin git@github.com:${{ github.repository }}.git
-          git tag ${{ needs.validation.outputs.RELEASE_VERSION }}
+          git tag -a ${{ needs.validation.outputs.RELEASE_VERSION }} -m "Release 0.1.1-cloudevents"
           git push origin ${{ needs.validation.outputs.RELEASE_VERSION }}
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
## WHAT

Unsigned operations (bump-version, release) now use deploy key + FX-Bot GPG key

dependency check now does not check fa3st dependencies (they are not available via maven repos and thus all use this project's license, Apache License, Version 2.0)

## WHY

Release workflow crashing due to insufficient permissions, see https://github.com/factory-x-contributions/fa3st-service/actions/runs/17826325376/job/50680288252#step:3:203 

## FURTHER NOTES

Also removed opc-ua workaround

Closes #16 