### PR TITLE
Add OAuth Token to MQTT Client sending Cloudevents

### DIFF
--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudeventsConfig.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudeventsConfig.java
@@ -41,6 +41,8 @@ public class MessageBusCloudeventsConfig extends MessageBusConfig<MessageBusClou
     private String topicPrefix;
     private boolean slimEvents;
     private String eventCallbackAddress;
+    private String secret;
+    private String identityProviderUrl;
 
     public MessageBusCloudeventsConfig() {
         this.host = DEFAULT_HOST;
@@ -64,6 +66,26 @@ public class MessageBusCloudeventsConfig extends MessageBusConfig<MessageBusClou
 
     public void setClientId(String clientId) {
         this.clientId = clientId;
+    }
+
+
+    public String getSecret() {
+        return secret;
+    }
+
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+
+    public String getIdentityProviderUrl() {
+        return identityProviderUrl;
+    }
+
+
+    public void setIdentityProviderUrl(String identityProviderUrl) {
+        this.identityProviderUrl = identityProviderUrl;
     }
 
 
@@ -242,6 +264,18 @@ public class MessageBusCloudeventsConfig extends MessageBusConfig<MessageBusClou
 
         public B slimEvents(boolean value) {
             getBuildingInstance().setSlimEvents(value);
+            return getSelf();
+        }
+
+
+        public B identityProviderUrl(String value) {
+            getBuildingInstance().setIdentityProviderUrl(value);
+            return getSelf();
+        }
+
+
+        public B secret(String value) {
+            getBuildingInstance().setSecret(value);
             return getSelf();
         }
 

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudeventsConfig.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudeventsConfig.java
@@ -69,12 +69,12 @@ public class MessageBusCloudeventsConfig extends MessageBusConfig<MessageBusClou
     }
 
 
-    public String getSecret() {
+    public String getClientSecret() {
         return secret;
     }
 
 
-    public void setSecret(String secret) {
+    public void setClientSecret(String secret) {
         this.secret = secret;
     }
 
@@ -274,8 +274,8 @@ public class MessageBusCloudeventsConfig extends MessageBusConfig<MessageBusClou
         }
 
 
-        public B secret(String value) {
-            getBuildingInstance().setSecret(value);
+        public B clientSecret(String value) {
+            getBuildingInstance().setClientSecret(value);
             return getSelf();
         }
 

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * Eclipse Paho MQTT client that:
  * fetches an OAuth2 access token (client credentials) from config.getIdentityProviderUrl()
  * using client credentials from config.getClientId(), getClientSecret;
- * connects over WebSocket and sends Authorization: Bearer <token> header.
+ * connects over WebSocket and sends Authorization: Bearer token header.
  * refreshes token proactively and updates headers so auto-reconnect uses a valid token.
  */
 public class PahoClient {

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
@@ -366,8 +366,8 @@ public class PahoClient {
         return tr;
     }
 
-    private static class TokenResponse {
-        String accessToken;
-        long expiresIn;
+    public static class TokenResponse {
+        public String accessToken;
+        public Long expiresIn;
     }
 }

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
@@ -32,7 +32,6 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -278,10 +277,8 @@ public class PahoClient {
 
 
     private void applyAuthorizationHeader(MqttConnectOptions options, String token) {
-        Properties headers = new Properties();
-        headers.setProperty("Authorization", "Bearer " + token);
-        options.setCustomWebSocketHeaders(headers);
-        logger.debug("Applied Authorization header for WebSocket");
+        options.setPassword(token.toCharArray());
+        logger.debug("Applied token as password");
     }
 
 

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
@@ -366,6 +366,9 @@ public class PahoClient {
         return tr;
     }
 
+    /**
+     * Class for Response containing token and expiresIn as well as other stuff not being read.
+     */
     public static class TokenResponse {
         public String accessToken;
         public Long expiresIn;


### PR DESCRIPTION
## WHAT

Adds OAuth Token Request and puts the token inside the Websocket Auth Header.
Required for new RabbitMQ Cloudevents

## WHY

RabbitMQ was introduced with OAuth

## Issue

Fixes https://github.com/factory-x-contributions/fa3st-service/issues/2

## FURTHER NOTES

Tested with Leon