### PR TITLE
Fix/messagebus cloudevents internal events

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
@@ -217,9 +217,11 @@ public class RegistrySynchronization {
         }
         switch (key.getType()) {
             case ASSET_ADMINISTRATION_SHELL:
+                LOGGER.debug("Notifying shell registries {} of {}", coreConfig.getAasRegistries(), event.getClass().getSimpleName());
                 aasHandler.accept(key.getValue());
                 break;
             case SUBMODEL:
+                LOGGER.debug("Notifying submodel registries {} of {}", coreConfig.getSubmodelRegistries(), event.getClass().getSimpleName());
                 submodelHandler.accept(key.getValue());
                 break;
         }

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudevents.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudevents.java
@@ -72,7 +72,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.eclipse.digitaltwin.aas4j.v3.model.HasSemantics;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
@@ -102,7 +101,6 @@ public class MessageBusCloudevents implements MessageBus<MessageBusCloudeventsCo
     private MessageBusCloudeventsConfig config;
     private PahoClient client;
     private ObjectMapper objectMapper;
-
 
     public MessageBusCloudevents() {
         running = new AtomicBoolean(false);

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudevents.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudevents.java
@@ -83,6 +83,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * MessageBusCloudevents: Implements the external MessageBus interface and publishes/dispatchesEventMessages.
+ *
  * <p>
  * Also implements the internal messagebus functionality to support internal components relying on Events.
  */

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudevents.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudevents.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import de.fraunhofer.iosb.ilt.faaast.service.ServiceContext;
 import de.fraunhofer.iosb.ilt.faaast.service.config.CoreConfig;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
-import de.fraunhofer.iosb.ilt.faaast.service.dataformat.json.JsonEventDeserializer;
 import de.fraunhofer.iosb.ilt.faaast.service.exception.MessageBusException;
 import de.fraunhofer.iosb.ilt.faaast.service.messagebus.MessageBus;
 import de.fraunhofer.iosb.ilt.faaast.service.model.IdShortPath;
@@ -66,7 +65,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.eclipse.digitaltwin.aas4j.v3.model.HasSemantics;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
@@ -78,6 +84,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * MessageBusCloudevents: Implements the external MessageBus interface and publishes/dispatchesEventMessages.
+ * <p>
+ * Also implements the internal messagebus functionality to support internal components relying on Events.
  */
 public class MessageBusCloudevents implements MessageBus<MessageBusCloudeventsConfig> {
 
@@ -85,42 +93,55 @@ public class MessageBusCloudevents implements MessageBus<MessageBusCloudeventsCo
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageBusCloudevents.class);
 
+    // Prepare internal message bus to not interfere with internal communications
+    private final BlockingQueue<EventMessage> messageQueue;
+    private final AtomicBoolean running;
+    private final ExecutorService executor;
+
     private final Map<SubscriptionId, SubscriptionInfo> subscriptions;
-    private final JsonEventDeserializer deserializer;
     private MessageBusCloudeventsConfig config;
     private PahoClient client;
     private ObjectMapper objectMapper;
 
+
     public MessageBusCloudevents() {
+        running = new AtomicBoolean(false);
+        messageQueue = new LinkedBlockingDeque<>();
+
         subscriptions = new ConcurrentHashMap<>();
-        deserializer = new JsonEventDeserializer();
+        executor = Executors.newSingleThreadExecutor();
     }
 
 
     @Override
     public void start() throws MessageBusException {
         client.start();
+
+        executor.submit(this::run);
     }
 
 
     @Override
     public void stop() {
         client.stop();
+
+        running.set(false);
+        executor.shutdown();
+
+        try {
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException e) {
+            LOGGER.error("interrupted while waiting for shutdown.", e);
+            Thread.currentThread().interrupt();
+        }
     }
 
 
     @Override
     public SubscriptionId subscribe(SubscriptionInfo subscriptionInfo) {
+        // Note: this only pertains to local subscriptions. Subscriptions to the cloudevents MQTT broker are handled by that component
         Ensure.requireNonNull(subscriptionInfo, "subscriptionInfo must be non-null");
-        subscriptionInfo.getSubscribedEvents()
-                .forEach(x -> determineEvents((Class<? extends EventMessage>) x)
-                        .forEach(e -> client.subscribe(config.getTopicPrefix().concat(getEventType(e)), (t, message) -> {
-                            EventMessage event = deserializer.read(message.toString(), e);
-                            if (subscriptionInfo.getFilter().test(event.getElement())) {
-                                subscriptionInfo.getHandler().accept(event);
-                            }
-                        })));
-
         SubscriptionId subscriptionId = new SubscriptionId();
         subscriptions.put(subscriptionId, subscriptionInfo);
         return subscriptionId;
@@ -129,11 +150,7 @@ public class MessageBusCloudevents implements MessageBus<MessageBusCloudeventsCo
 
     @Override
     public void unsubscribe(SubscriptionId id) {
-        SubscriptionInfo info = subscriptions.get(id);
-        Ensure.requireNonNull(info.getSubscribedEvents(), "subscriptionInfo must be non-null");
-        subscriptions.get(id).getSubscribedEvents().stream().forEach(a -> //find all events for given abstract or event
-                determineEvents((Class<? extends EventMessage>) a).stream().forEach(e -> //unsubscribe from all events
-                        client.unsubscribe(config.getTopicPrefix() + e.getSimpleName())));
+        // Note: this only pertains to local subscriptions. Subscriptions to the cloudevents MQTT broker are handled by that component
         subscriptions.remove(id);
     }
 
@@ -153,6 +170,8 @@ public class MessageBusCloudevents implements MessageBus<MessageBusCloudeventsCo
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         objectMapper.registerModule(JsonFormat.getCloudEventJacksonModule());
+
+        running.set(false);
     }
 
 
@@ -162,10 +181,36 @@ public class MessageBusCloudevents implements MessageBus<MessageBusCloudeventsCo
         try {
             CloudEvent cloudMessage = createCloudevent(message);
             client.publish(config.getTopicPrefix(), objectMapper.writeValueAsString(cloudMessage));
+            // Also distribute event in internal message bus
+            messageQueue.put(message);
         }
         catch (JsonProcessingException | URISyntaxException | SerializationException publishException) {
             throw new MessageBusException(String.format(PUBLISH_ERROR_MSG, publishException.getClass().getSimpleName(), message.getClass()),
                     publishException);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MessageBusException("adding message to internal queue failed", e);
+        }
+    }
+
+
+    private void run() {
+        running.set(true);
+        try {
+            while (running.get()) {
+                EventMessage message = messageQueue.take();
+                Class<? extends EventMessage> messageType = message.getClass();
+                for (SubscriptionInfo subscription: subscriptions.values()) {
+                    if (subscription.getSubscribedEvents().stream().anyMatch(x -> x.isAssignableFrom(messageType))
+                            && subscription.getFilter().test(message.getElement())) {
+                        subscription.getHandler().accept(message);
+                    }
+                }
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/PahoClient.java
@@ -241,7 +241,7 @@ public class PahoClient {
         MqttMessage msg = new MqttMessage(content.getBytes());
         try {
             mqttClient.publish(topic, msg);
-            logger.info("message published - topic: {}, data: {}", topic, content);
+            logger.info("message published - server: {} topic: {}, data: {}", mqttClient.getServerURI(), topic, content);
         }
         catch (MqttException e) {
             throw new MessageBusException("publishing message on Cloudevents MQTT message bus failed", e);


### PR DESCRIPTION
## WHAT

Fixes registry synchronization when the cloud events message bus is used.

For this, elements of the internal message bus are implemented in the cloudEvents message bus. For each occurring event, a message is sent to the MQTT broker as well as the list of internal subscribers. This ensures that internal components that rely on events will actually receive them.

## WHY

The cloud events message bus currently does not distribute events to internal subscribers correctly. It tries to deserialize event data (CloudEvent) to FA³ST EventMessages.

## FURTHER NOTES

This should only be an intermediate solution. A more robust proposal would be to employ a mandatory internal message bus from which extensions could be implemented that, for example, send a notification to an MQTT broker.

edit: custom message buses could also wildcard-subscribe to the internal message bus (or subscribe to needed event types) and distribute them like that. this would demote them to simple components of the service