### PR TITLE
fix: registry sync + callback address

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/config/CoreConfig.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/config/CoreConfig.java
@@ -15,6 +15,7 @@
 package de.fraunhofer.iosb.ilt.faaast.service.config;
 
 import de.fraunhofer.iosb.ilt.faaast.service.model.validation.ModelValidatorConfig;
+import de.fraunhofer.iosb.ilt.faaast.service.util.Ensure;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -32,6 +33,7 @@ public class CoreConfig {
     private static final long DEFAULT_ASSET_CONNECTION_RETRY_INTERVAL = 1000;
     private static final int DEFAULT_REQUEST_HANDLER_THREADPOOL_SIZE = 1;
     private static final double DEFAULT_MIN_INFLATE_RATIO = 0.001;
+    private static final String ALLOWED_URL_PREFIX_REGEX = "https?://.*";
 
     private long assetConnectionRetryInterval;
     private int requestHandlerThreadPoolSize;
@@ -127,7 +129,13 @@ public class CoreConfig {
     }
 
 
+    /**
+     * Sets the AAS registries. Each URL must start with either http:// or https://.
+     *
+     * @param aasRegistries The aasRegistries URL list as a list of strings.
+     */
     public void setAasRegistries(List<String> aasRegistries) {
+        validateRegistryUrl(aasRegistries);
         this.aasRegistries = aasRegistries;
     }
 
@@ -137,8 +145,22 @@ public class CoreConfig {
     }
 
 
+    /**
+     * Sets the submodel registries. Each URL must start with either http:// or https://.
+     *
+     * @param submodelRegistries The submodelRegistries URL list as a list of strings.
+     */
     public void setSubmodelRegistries(List<String> submodelRegistries) {
+        validateRegistryUrl(submodelRegistries);
         this.submodelRegistries = submodelRegistries;
+    }
+
+
+    private void validateRegistryUrl(List<String> registryUrls) {
+        for (String url: registryUrls) {
+            Ensure.require(url.matches(ALLOWED_URL_PREFIX_REGEX), String.format("URLs in %s.%s must start with https:// or http://, but one of them is: %s",
+                    this.getClass().getSimpleName(), "(aas|submodel)Registries", url));
+        }
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
@@ -40,6 +40,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.util.ReferenceHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.util.SslHelper;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
@@ -71,8 +72,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Class to handle the synchronisation of assetAdministrationShells and submodels
- * with the Registry.
+ * Class to handle the synchronisation of assetAdministrationShells and submodels with the Registry.
  */
 public class RegistrySynchronization {
     private static final Logger LOGGER = LoggerFactory.getLogger(RegistrySynchronization.class);
@@ -495,7 +495,8 @@ public class RegistrySynchronization {
                             responseMessages,
                             response.statusCode()));
                 }
-                catch (IOException | InterruptedException | KeyManagementException | NoSuchAlgorithmException | SerializationException | DeserializationException e) {
+                catch (IOException | InterruptedException | KeyManagementException | NoSuchAlgorithmException | SerializationException | DeserializationException
+                        | URISyntaxException e) {
                     LOGGER.warn(String.format(
                             errorMsg,
                             id,
@@ -512,18 +513,30 @@ public class RegistrySynchronization {
 
 
     private HttpResponse<String> execute(HttpMethod method, String baseUrl, String path, Object payload)
-            throws IOException, InterruptedException, KeyManagementException, NoSuchAlgorithmException, SerializationException {
+            throws IOException, InterruptedException, KeyManagementException, NoSuchAlgorithmException, SerializationException, URISyntaxException {
         Ensure.requireNonNull(method, "method must be non-null");
         Ensure.requireNonNull(baseUrl, "baseUrl must be non-null");
         Ensure.requireNonNull(path, "path must be non-null");
         Ensure.requireNonNull(payload, "payload must be non-null");
-        String safeBaseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl.concat("/");
+        URI sanitizedBaseUrl = sanitize(baseUrl).resolve(path);
+
         HttpRequest.Builder builder = HttpRequest.newBuilder()
-                .uri(URI.create(safeBaseUrl).resolve(path))
+                .uri(sanitizedBaseUrl)
                 .header("Content-Type", "application/json");
         requestDecorator.decorate(builder);
         HttpRequest request = builder.method(method.toString(), HttpRequest.BodyPublishers.ofString(mapper.write(payload))).build();
         return SslHelper.newClientAcceptingAllCertificates().send(request, BodyHandlers.ofString());
+    }
+
+
+    private URI sanitize(String baseUrl) throws URISyntaxException {
+        String sanitized = baseUrl.endsWith("/") ? baseUrl : baseUrl.concat("/");
+        URI sanitizedUri = URI.create(sanitized);
+        String scheme = sanitizedUri.getScheme();
+        if (scheme == null || !(scheme.equals("https") || scheme.equals("http"))) {
+            sanitizedUri = new URI("https://".concat(sanitizedUri.toString()));
+        }
+        return sanitizedUri;
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
@@ -40,7 +40,6 @@ import de.fraunhofer.iosb.ilt.faaast.service.util.ReferenceHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.util.SslHelper;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
@@ -495,8 +494,7 @@ public class RegistrySynchronization {
                             responseMessages,
                             response.statusCode()));
                 }
-                catch (IOException | InterruptedException | KeyManagementException | NoSuchAlgorithmException | SerializationException | DeserializationException
-                        | URISyntaxException e) {
+                catch (IOException | InterruptedException | KeyManagementException | NoSuchAlgorithmException | SerializationException | DeserializationException e) {
                     LOGGER.warn(String.format(
                             errorMsg,
                             id,
@@ -513,30 +511,21 @@ public class RegistrySynchronization {
 
 
     private HttpResponse<String> execute(HttpMethod method, String baseUrl, String path, Object payload)
-            throws IOException, InterruptedException, KeyManagementException, NoSuchAlgorithmException, SerializationException, URISyntaxException {
+            throws IOException, InterruptedException, KeyManagementException, NoSuchAlgorithmException, SerializationException {
         Ensure.requireNonNull(method, "method must be non-null");
         Ensure.requireNonNull(baseUrl, "baseUrl must be non-null");
         Ensure.requireNonNull(path, "path must be non-null");
         Ensure.requireNonNull(payload, "payload must be non-null");
-        URI sanitizedBaseUrl = sanitize(baseUrl).resolve(path);
+
+        // URI.resolve will remove the path if it is not suffixed by "/"
+        String safeBaseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl.concat("/");
 
         HttpRequest.Builder builder = HttpRequest.newBuilder()
-                .uri(sanitizedBaseUrl)
+                .uri(URI.create(safeBaseUrl).resolve(path))
                 .header("Content-Type", "application/json");
         requestDecorator.decorate(builder);
         HttpRequest request = builder.method(method.toString(), HttpRequest.BodyPublishers.ofString(mapper.write(payload))).build();
         return SslHelper.newClientAcceptingAllCertificates().send(request, BodyHandlers.ofString());
-    }
-
-
-    private URI sanitize(String baseUrl) throws URISyntaxException {
-        String sanitized = baseUrl.endsWith("/") ? baseUrl : baseUrl.concat("/");
-        URI sanitizedUri = URI.create(sanitized);
-        String scheme = sanitizedUri.getScheme();
-        if (scheme == null || !(scheme.equals("https") || scheme.equals("http"))) {
-            sanitizedUri = new URI("https://".concat(sanitizedUri.toString()));
-        }
-        return sanitizedUri;
     }
 
 

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
@@ -52,7 +52,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEndpoint;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProtocolInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSecurityAttributeObject;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
@@ -52,6 +52,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEndpoint;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProtocolInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSecurityAttributeObject;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
@@ -288,10 +289,10 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
 
 
     private org.eclipse.digitaltwin.aas4j.v3.model.Endpoint endpointFor(Interface iface, String path, String identifiableId) {
-        URI endpointUri = buildUri(getEndpointUri().toString(), getPathPrefix(), path);
+        URI endpointUri = buildUri(getEndpointUri(), path);
 
         if (iface == Interface.SUBMODEL || iface == Interface.AAS) {
-            endpointUri = buildUri(endpointUri.toString(), EncodingHelper.base64UrlEncode(identifiableId));
+            endpointUri = buildUri(endpointUri, EncodingHelper.base64UrlEncode(identifiableId));
         }
 
         return new DefaultEndpoint.Builder()
@@ -326,7 +327,7 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
         try {
             if (Objects.nonNull(config.getCallbackAddress())) {
                 result = buildUri(
-                        config.getCallbackAddress(),
+                        URI.create(config.getCallbackAddress()),
                         // server URI path comes before configured prefix
                         result.getPath(),
                         config.getPathPrefix());
@@ -351,8 +352,15 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
     }
 
 
-    private URI buildUri(String base, String... paths) {
-        String safeBase = base.endsWith("/") ? base : base.concat("/");
+    private URI buildUri(URI base, String... paths) {
+        URI safeBase = base;
+        String scheme = safeBase.getScheme();
+        // callback address can only have http(s) for HTTP endpoint
+        if (scheme == null || !(scheme.equals(HttpScheme.HTTPS.toString()) || scheme.equals(HttpScheme.HTTP.toString()))) {
+            safeBase = URI.create(HttpScheme.HTTPS.toString().concat("://").concat(safeBase.toString()));
+        }
+        safeBase = safeBase.toString().endsWith("/") ? safeBase : URI.create(safeBase.toString().concat("/"));
+
         StringBuilder safePathBuilder = new StringBuilder();
         for (String path: paths) {
             if (path == null || path.isBlank()) {
@@ -360,13 +368,17 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
             }
             safePathBuilder.append(path.startsWith("/") ? path : path.concat("/"));
         }
+
         String safePath = safePathBuilder.toString();
-        if (safePath.startsWith("/")) {
+
+        safePath = safePath.replace("//", "/");
+
+        while (safePath.startsWith("/")) {
             safePath = safePath.substring(1);
         }
 
         // Remove leading slash again
-        return URI.create(safeBase).resolve(safePath);
+        return safeBase.resolve(safePath);
     }
 
 

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
@@ -67,7 +67,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of HTTP endpoint. Accepts http request and maps them to Request objects passes them to the service and
- * expects a response object which is streamed as json response to the http client
+ * expects a response object which is streamed as json
+ * response to the http client
  */
 public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
 
@@ -254,13 +255,12 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
         if (config.getProfiles().stream()
                 .flatMap(x -> x.getInterfaces().stream())
                 .anyMatch(x -> Objects.equals(x, Interface.AAS_REPOSITORY))) {
-            // Intentionally omitting trailing slash for path. *_REPOSITORY-Endpoint does not append id to path.
-            result.add(endpointFor(Interface.AAS_REPOSITORY, "/shells", aasId));
+            result.add(endpointFor(Interface.AAS_REPOSITORY, "shells", aasId));
         }
         if (config.getProfiles().stream()
                 .flatMap(x -> x.getInterfaces().stream())
                 .anyMatch(x -> Objects.equals(x, Interface.AAS))) {
-            result.add(endpointFor(Interface.AAS, "/shells/", aasId));
+            result.add(endpointFor(Interface.AAS, "shells", aasId));
         }
         return result;
     }
@@ -275,13 +275,12 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
         if (config.getProfiles().stream()
                 .flatMap(x -> x.getInterfaces().stream())
                 .anyMatch(x -> Objects.equals(x, Interface.SUBMODEL_REPOSITORY))) {
-            // Intentionally omitting trailing slash for path. *_REPOSITORY-Endpoint does not append id to path.
-            result.add(endpointFor(Interface.SUBMODEL_REPOSITORY, "/submodels", submodelId));
+            result.add(endpointFor(Interface.SUBMODEL_REPOSITORY, "submodels", submodelId));
         }
         if (config.getProfiles().stream()
                 .flatMap(x -> x.getInterfaces().stream())
                 .anyMatch(x -> Objects.equals(x, Interface.SUBMODEL))) {
-            result.add(endpointFor(Interface.SUBMODEL, "/submodels/", submodelId));
+            result.add(endpointFor(Interface.SUBMODEL, "submodels", submodelId));
         }
 
         return result;
@@ -289,10 +288,10 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
 
 
     private org.eclipse.digitaltwin.aas4j.v3.model.Endpoint endpointFor(Interface iface, String path, String identifiableId) {
-        URI endpointUri = buildUri(getEndpointUri(), path);
+        URI endpointUri = buildUri(getEndpointUri().toString(), path);
 
         if (iface == Interface.SUBMODEL || iface == Interface.AAS) {
-            endpointUri = buildUri(endpointUri, EncodingHelper.base64UrlEncode(identifiableId));
+            endpointUri = buildUri(endpointUri.toString(), EncodingHelper.base64UrlEncode(identifiableId));
         }
 
         return new DefaultEndpoint.Builder()
@@ -327,7 +326,7 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
         try {
             if (Objects.nonNull(config.getCallbackAddress())) {
                 result = buildUri(
-                        URI.create(config.getCallbackAddress()),
+                        config.getCallbackAddress(),
                         // server URI path comes before configured prefix
                         result.getPath(),
                         config.getPathPrefix());
@@ -352,33 +351,31 @@ public class HttpEndpoint extends AbstractEndpoint<HttpEndpointConfig> {
     }
 
 
-    private URI buildUri(URI base, String... paths) {
-        URI safeBase = base;
-        String scheme = safeBase.getScheme();
-        // callback address can only have http(s) for HTTP endpoint
-        if (scheme == null || !(scheme.equals(HttpScheme.HTTPS.toString()) || scheme.equals(HttpScheme.HTTP.toString()))) {
-            safeBase = URI.create(HttpScheme.HTTPS.toString().concat("://").concat(safeBase.toString()));
-        }
-        safeBase = safeBase.toString().endsWith("/") ? safeBase : URI.create(safeBase.toString().concat("/"));
+    private URI buildUri(String base, String... paths) {
+        String safeBase = base.endsWith("/") ? base : base.concat("/");
 
+        String safePath = getSafePath(paths);
+
+        return URI.create(safeBase).resolve(safePath);
+    }
+
+
+    private String getSafePath(String[] paths) {
         StringBuilder safePathBuilder = new StringBuilder();
+
+        // Each path in paths should not start with / but end with /.
         for (String path: paths) {
-            if (path == null || path.isBlank()) {
+            if (path == null || path.isEmpty() || path.equals("/")) {
+                // Do not consider empty path segments
                 continue;
             }
-            safePathBuilder.append(path.startsWith("/") ? path : path.concat("/"));
+            // Double-slashes within path segments are valid and sometimes even meaningful,
+            // so we only care about the bits connecting the path segments (prefix/suffix).
+            String safePath = path.startsWith("/") ? path.substring(1) : path;
+            safePathBuilder.append(safePath.endsWith("/") ? safePath : safePath.concat("/"));
         }
 
-        String safePath = safePathBuilder.toString();
-
-        safePath = safePath.replace("//", "/");
-
-        while (safePath.startsWith("/")) {
-            safePath = safePath.substring(1);
-        }
-
-        // Remove leading slash again
-        return safeBase.resolve(safePath);
+        return safePathBuilder.toString().endsWith("/") ? safePathBuilder.substring(0, safePathBuilder.length() - 1) : safePathBuilder.toString();
     }
 
 

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/AbstractHttpEndpointTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/AbstractHttpEndpointTest.java
@@ -929,13 +929,13 @@ public abstract class AbstractHttpEndpointTest {
 
 
     protected ContentResponse execute(
-            HttpMethod method,
-            String path,
-            Map<String, String> parameters,
-            Content content,
-            String body,
-            String contentType,
-            Map<String, String> headers)
+                                      HttpMethod method,
+                                      String path,
+                                      Map<String, String> parameters,
+                                      Content content,
+                                      String body,
+                                      String contentType,
+                                      Map<String, String> headers)
             throws Exception {
         String actualPath = path;
         if (Objects.nonNull(content) && !Objects.equals(content, Content.NORMAL)) {

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/AbstractHttpEndpointTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/AbstractHttpEndpointTest.java
@@ -75,14 +75,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.ContentType;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
+import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.ExecutionState;
 import org.eclipse.digitaltwin.aas4j.v3.model.MessageTypeEnum;
+import org.eclipse.digitaltwin.aas4j.v3.model.ProtocolInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.Result;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
@@ -296,6 +299,22 @@ public abstract class AbstractHttpEndpointTest {
         ContentResponse response = execute(HttpMethod.GET, "/submodels/" + EncodingHelper.base64UrlEncode(idShort)
                 + "/submodel-elements/ExampleRelationshipElement?level=normal&bogus");
         Assert.assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+    }
+
+
+    @Test
+    public void testGetAasEndpointInformationWithCallbackAddress() {
+        List<Endpoint> actual = endpoint.getAasEndpointInformation(UUID.randomUUID().toString());
+
+        ProtocolInformation protocolInformation = actual.get(0).getProtocolInformation();
+
+        HttpEndpointConfig config = endpoint.asConfig();
+        if (config.getCallbackAddress() != null) {
+            Assert.assertEquals(config.getCallbackAddress().concat(endpoint.getPathPrefix()).concat("/shells"), protocolInformation.getHref());
+        }
+        Assert.assertEquals(config.getSubprotocol(), protocolInformation.getSubprotocol());
+        Assert.assertEquals(config.getSubprotocolBody(), protocolInformation.getSubprotocolBody());
+        Assert.assertEquals(config.getSubprotocolBodyEncoding(), protocolInformation.getSubprotocolBodyEncoding());
     }
 
 
@@ -910,13 +929,13 @@ public abstract class AbstractHttpEndpointTest {
 
 
     protected ContentResponse execute(
-                                      HttpMethod method,
-                                      String path,
-                                      Map<String, String> parameters,
-                                      Content content,
-                                      String body,
-                                      String contentType,
-                                      Map<String, String> headers)
+            HttpMethod method,
+            String path,
+            Map<String, String> parameters,
+            Content content,
+            String body,
+            String contentType,
+            Map<String, String> headers)
             throws Exception {
         String actualPath = path;
         if (Objects.nonNull(content) && !Objects.equals(content, Content.NORMAL)) {

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpointWithExtendedEndpointInformationTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpointWithExtendedEndpointInformationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import de.fraunhofer.iosb.ilt.faaast.service.Service;
+import de.fraunhofer.iosb.ilt.faaast.service.config.CoreConfig;
+import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.serialization.HttpJsonApiDeserializer;
+import de.fraunhofer.iosb.ilt.faaast.service.filestorage.FileStorage;
+import de.fraunhofer.iosb.ilt.faaast.service.messagebus.MessageBus;
+import de.fraunhofer.iosb.ilt.faaast.service.persistence.Persistence;
+import de.fraunhofer.iosb.ilt.faaast.service.util.PortHelper;
+import java.util.List;
+import java.util.UUID;
+import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
+import org.eclipse.digitaltwin.aas4j.v3.model.ProtocolInformation;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.server.Server;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+public class HttpEndpointWithExtendedEndpointInformationTest extends AbstractHttpEndpointTest {
+
+    private static final String subprotocol = "EXAMPLE";
+    private static final String subprotocolBody = "my-example-subprotocol-body";
+    private static final String subprotocolBodyEncoding = "none";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        port = PortHelper.findFreePort();
+        deserializer = new HttpJsonApiDeserializer();
+        persistence = mock(Persistence.class);
+        fileStorage = mock(FileStorage.class);
+        startServer();
+        startClient();
+    }
+
+
+    private static void startServer() throws Exception {
+        scheme = HttpScheme.HTTP.toString();
+        endpoint = new HttpEndpoint();
+        server = new Server();
+        service = spy(new Service(CoreConfig.DEFAULT, persistence, fileStorage, mock(MessageBus.class), List.of(endpoint), List.of(), List.of()));
+        endpoint.init(
+                CoreConfig.DEFAULT,
+                HttpEndpointConfig.builder()
+                        .port(port)
+                        .cors(true)
+                        .ssl(false)
+                        .build(),
+                service);
+        server.start();
+        service.start();
+    }
+
+
+    private static void startClient() throws Exception {
+        client = new HttpClient(new HttpClientTransportDynamic(new ClientConnector()));
+        client.start();
+    }
+
+
+    @Test
+    public void testGetAasEndpointInformationWithCallbackAddress() {
+        String callbackAddress = "https://invalid.local:1234/path";
+        endpoint.init(
+                CoreConfig.DEFAULT,
+                HttpEndpointConfig.builder()
+                        .port(port)
+                        .cors(true)
+                        .ssl(false)
+                        .callbackAddress(callbackAddress)
+                        .subprotocol(subprotocol)
+                        .subprotocolBody(subprotocolBody)
+                        .subprotocolBodyEncoding(subprotocolBodyEncoding)
+                        .hostname("http://willbeoverridden.local:4242/example")
+                        .build(),
+                service);
+
+        String expectedHref = callbackAddress.concat(endpoint.getPathPrefix()).concat("/shells");
+        List<Endpoint> actual = endpoint.getAasEndpointInformation(UUID.randomUUID().toString());
+
+        assertProtocolInformation(actual.get(0).getProtocolInformation(), expectedHref);
+    }
+
+
+    @Test
+    public void testGetAasEndpointInformationWithCallbackAddressNoScheme() {
+        String callbackAddressMissingScheme = "invalid.local:1234/path";
+        endpoint.init(
+                CoreConfig.DEFAULT,
+                HttpEndpointConfig.builder()
+                        .port(port)
+                        .cors(true)
+                        .ssl(false)
+                        .callbackAddress(callbackAddressMissingScheme)
+                        .subprotocol(subprotocol)
+                        .subprotocolBody(subprotocolBody)
+                        .subprotocolBodyEncoding(subprotocolBodyEncoding)
+                        .hostname("http://willbeoverridden.local:4242/example")
+                        .build(),
+                service);
+
+        String expectedHref = "https://".concat(callbackAddressMissingScheme).concat(endpoint.getPathPrefix()).concat("/shells");
+        List<Endpoint> actual = endpoint.getAasEndpointInformation(UUID.randomUUID().toString());
+
+        assertProtocolInformation(actual.get(0).getProtocolInformation(), expectedHref);
+    }
+
+
+    private void assertProtocolInformation(ProtocolInformation protocolInformation, String expectedCallbackAddress) {
+        Assert.assertEquals(expectedCallbackAddress, protocolInformation.getHref());
+        Assert.assertEquals(subprotocol, protocolInformation.getSubprotocol());
+        Assert.assertEquals(subprotocolBody, protocolInformation.getSubprotocolBody());
+        Assert.assertEquals(subprotocolBodyEncoding, protocolInformation.getSubprotocolBodyEncoding());
+    }
+}

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpointWithExtendedEndpointInformationTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpointWithExtendedEndpointInformationTest.java
@@ -25,24 +25,15 @@ import de.fraunhofer.iosb.ilt.faaast.service.messagebus.MessageBus;
 import de.fraunhofer.iosb.ilt.faaast.service.persistence.Persistence;
 import de.fraunhofer.iosb.ilt.faaast.service.util.PortHelper;
 import java.util.List;
-import java.util.UUID;
-import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
-import org.eclipse.digitaltwin.aas4j.v3.model.ProtocolInformation;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.server.Server;
-import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 
 public class HttpEndpointWithExtendedEndpointInformationTest extends AbstractHttpEndpointTest {
-
-    private static final String subprotocol = "EXAMPLE";
-    private static final String subprotocolBody = "my-example-subprotocol-body";
-    private static final String subprotocolBodyEncoding = "none";
 
     @BeforeClass
     public static void init() throws Exception {
@@ -76,61 +67,5 @@ public class HttpEndpointWithExtendedEndpointInformationTest extends AbstractHtt
     private static void startClient() throws Exception {
         client = new HttpClient(new HttpClientTransportDynamic(new ClientConnector()));
         client.start();
-    }
-
-
-    @Test
-    public void testGetAasEndpointInformationWithCallbackAddress() {
-        String callbackAddress = "https://invalid.local:1234/path";
-        endpoint.init(
-                CoreConfig.DEFAULT,
-                HttpEndpointConfig.builder()
-                        .port(port)
-                        .cors(true)
-                        .ssl(false)
-                        .callbackAddress(callbackAddress)
-                        .subprotocol(subprotocol)
-                        .subprotocolBody(subprotocolBody)
-                        .subprotocolBodyEncoding(subprotocolBodyEncoding)
-                        .hostname("http://willbeoverridden.local:4242/example")
-                        .build(),
-                service);
-
-        String expectedHref = callbackAddress.concat(endpoint.getPathPrefix()).concat("/shells");
-        List<Endpoint> actual = endpoint.getAasEndpointInformation(UUID.randomUUID().toString());
-
-        assertProtocolInformation(actual.get(0).getProtocolInformation(), expectedHref);
-    }
-
-
-    @Test
-    public void testGetAasEndpointInformationWithCallbackAddressNoScheme() {
-        String callbackAddressMissingScheme = "invalid.local:1234/path";
-        endpoint.init(
-                CoreConfig.DEFAULT,
-                HttpEndpointConfig.builder()
-                        .port(port)
-                        .cors(true)
-                        .ssl(false)
-                        .callbackAddress(callbackAddressMissingScheme)
-                        .subprotocol(subprotocol)
-                        .subprotocolBody(subprotocolBody)
-                        .subprotocolBodyEncoding(subprotocolBodyEncoding)
-                        .hostname("http://willbeoverridden.local:4242/example")
-                        .build(),
-                service);
-
-        String expectedHref = "https://".concat(callbackAddressMissingScheme).concat(endpoint.getPathPrefix()).concat("/shells");
-        List<Endpoint> actual = endpoint.getAasEndpointInformation(UUID.randomUUID().toString());
-
-        assertProtocolInformation(actual.get(0).getProtocolInformation(), expectedHref);
-    }
-
-
-    private void assertProtocolInformation(ProtocolInformation protocolInformation, String expectedCallbackAddress) {
-        Assert.assertEquals(expectedCallbackAddress, protocolInformation.getHref());
-        Assert.assertEquals(subprotocol, protocolInformation.getSubprotocol());
-        Assert.assertEquals(subprotocolBody, protocolInformation.getSubprotocolBody());
-        Assert.assertEquals(subprotocolBodyEncoding, protocolInformation.getSubprotocolBodyEncoding());
     }
 }


### PR DESCRIPTION
## WHAT

Currently, two bugs appear when using `callbackAddress` in the http endpoint:

1. if `pathPrefix` is defined, it is appended twice to the `href` field in a descriptor
2. if `callbackAddress` contains path segments, they will be removed by the http endpoint

Also, if an `aasRegistries` / `submodelRegistries` URL does not contain a scheme (i.e. https, http), the registry synchronization will fail silently due to an IllegalArgumentException not being thrown into the console.


I have also added a HttpEndpoint test instance which differs from the others as it defines test cases itself. However, it differs from the other HttpEndpoint tests as it defines own test cases which could not be executed by the other instances due to missing configuration in the superclass.

## WHY

See above

## FURTHER NOTES

The same changes are being reviewed upstream currently.