### PR TITLE
fix: race condition messagebus vs. persistence

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/proprietary/ResetRequestHandler.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/proprietary/ResetRequestHandler.java
@@ -28,18 +28,20 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.noop.NoopEve
 import de.fraunhofer.iosb.ilt.faaast.service.request.handler.AbstractRequestHandler;
 import de.fraunhofer.iosb.ilt.faaast.service.request.handler.RequestExecutionContext;
 import de.fraunhofer.iosb.ilt.faaast.service.util.StreamHelper;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.util.AasUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-
 
 /**
- * Class to handle a {@link ResetRequest} in the service and to send the corresponding response {@link ResetResponse}. Is responsible for communication with the persistence. Note:
- * The side effects of this request can potentially hinder removal of descriptors at registries. It is advised not to issue any other request when using /reset. It is also possible
- * that the last submodel to be removed from a SubmodelRegistry will fail to be removed. This is due to the ordering of event handlers within the messagebus.
+ * Class to handle a {@link ResetRequest} in the service and to send the corresponding response {@link ResetResponse}.
+ * Is responsible for communication with the persistence. Note:
+ * The side effects of this request can potentially hinder removal of descriptors at registries. It is advised not to
+ * issue any other request when using /reset. It is also possible
+ * that the last submodel to be removed from a SubmodelRegistry will fail to be removed. This is due to the ordering of
+ * event handlers within the messagebus.
  */
 public class ResetRequestHandler extends AbstractRequestHandler<ResetRequest, ResetResponse> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResetRequestHandler.class);

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/proprietary/ResetRequestHandler.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/proprietary/ResetRequestHandler.java
@@ -21,7 +21,10 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.request.proprietary.ResetRequest;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.response.proprietary.ResetResponse;
 import de.fraunhofer.iosb.ilt.faaast.service.model.exception.PersistenceException;
+import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.SubscriptionId;
+import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.SubscriptionInfo;
 import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.change.ElementDeleteEventMessage;
+import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.noop.NoopEventMessage;
 import de.fraunhofer.iosb.ilt.faaast.service.request.handler.AbstractRequestHandler;
 import de.fraunhofer.iosb.ilt.faaast.service.request.handler.RequestExecutionContext;
 import de.fraunhofer.iosb.ilt.faaast.service.util.StreamHelper;
@@ -29,12 +32,14 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.util.AasUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
 
 /**
- * Class to handle a {@link ResetRequest}
- * in the service and to send the corresponding response
- * {@link ResetResponse}. Is responsible
- * for communication with the persistence.
+ * Class to handle a {@link ResetRequest} in the service and to send the corresponding response {@link ResetResponse}. Is responsible for communication with the persistence. Note:
+ * The side effects of this request can potentially hinder removal of descriptors at registries. It is advised not to issue any other request when using /reset. It is also possible
+ * that the last submodel to be removed from a SubmodelRegistry will fail to be removed. This is due to the ordering of event handlers within the messagebus.
  */
 public class ResetRequestHandler extends AbstractRequestHandler<ResetRequest, ResetResponse> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResetRequestHandler.class);
@@ -42,6 +47,17 @@ public class ResetRequestHandler extends AbstractRequestHandler<ResetRequest, Re
     @Override
     public ResetResponse process(ResetRequest request, RequestExecutionContext context) {
         try {
+            UUID uniqueNoopId = UUID.randomUUID();
+            CountDownLatch latch = new CountDownLatch(1);
+            // After publishing ElementDeleteEvents, one NoopEvent is published which we also listen for. Once this NoopEvent is handled, we know all DeleteEvents have
+            // been handled due to the FIFO nature of the message bus queue, except if the handlers use threading.
+            SubscriptionId subscriptionId = context.getMessageBus().subscribe(SubscriptionInfo.create(NoopEventMessage.class,
+                    x -> {
+                        if (x.getUuid().equals(uniqueNoopId)) {
+                            latch.countDown();
+                        }
+                    }));
+
             StreamHelper.concat(
                     context.getPersistence().getAllAssetAdministrationShells(QueryModifier.MINIMAL, PagingInfo.ALL).getContent().stream(),
                     context.getPersistence().getAllSubmodels(QueryModifier.MINIMAL, PagingInfo.ALL).getContent().stream(),
@@ -57,12 +73,19 @@ public class ResetRequestHandler extends AbstractRequestHandler<ResetRequest, Re
                             LOGGER.warn("Publishing ElementDeleteEvent on message bus during reset failed (reference: {})", AasUtils.toReference(x));
                         }
                     });
+
+            context.getMessageBus().publish(NoopEventMessage.builder().uuid(uniqueNoopId).build());
+            // Wait for noop event to be handled
+            latch.await();
+
             context.getAssetConnectionManager().reset();
             context.getPersistence().deleteAll();
             context.getFileStorage().deleteAll();
+
+            context.getMessageBus().unsubscribe(subscriptionId);
             return ResetResponse.builder().statusCode(StatusCode.SUCCESS_NO_CONTENT).build();
         }
-        catch (PersistenceException e) {
+        catch (PersistenceException | InterruptedException | MessageBusException e) {
             throw new IllegalStateException("Error resetting FA³ST Service - the server might now be in an undefined and unstable state. It is recommended to restart the server",
                     e);
         }

--- a/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/messagebus/event/noop/NoopEventMessage.java
+++ b/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/messagebus/event/noop/NoopEventMessage.java
@@ -1,7 +1,20 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.noop;
 
 import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.EventMessage;
-
 import java.util.Objects;
 import java.util.UUID;
 
@@ -12,7 +25,6 @@ import java.util.UUID;
 public class NoopEventMessage extends EventMessage {
 
     private UUID uuid;
-
 
     public NoopEventMessage() {
         this.uuid = UUID.randomUUID();
@@ -53,7 +65,6 @@ public class NoopEventMessage extends EventMessage {
         return new NoopEventMessage.Builder();
     }
 
-
     public abstract static class AbstractBuilder<T extends NoopEventMessage, B extends NoopEventMessage.AbstractBuilder<T, B>> extends EventMessage.AbstractBuilder<T, B> {
 
         public B uuid(UUID value) {
@@ -61,7 +72,6 @@ public class NoopEventMessage extends EventMessage {
             return getSelf();
         }
     }
-
 
     public static class Builder extends AbstractBuilder<NoopEventMessage, Builder> {
 

--- a/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/messagebus/event/noop/NoopEventMessage.java
+++ b/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/messagebus/event/noop/NoopEventMessage.java
@@ -1,0 +1,79 @@
+package de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.noop;
+
+import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.EventMessage;
+
+import java.util.Objects;
+import java.util.UUID;
+
+
+/**
+ * No-operation event used to analyze the flow of the message bus.
+ */
+public class NoopEventMessage extends EventMessage {
+
+    private UUID uuid;
+
+
+    public NoopEventMessage() {
+        this.uuid = UUID.randomUUID();
+    }
+
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NoopEventMessage that = (NoopEventMessage) o;
+        return super.equals(o)
+                && Objects.equals(uuid, that.uuid);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), uuid);
+    }
+
+
+    public static NoopEventMessage.Builder builder() {
+        return new NoopEventMessage.Builder();
+    }
+
+
+    public abstract static class AbstractBuilder<T extends NoopEventMessage, B extends NoopEventMessage.AbstractBuilder<T, B>> extends EventMessage.AbstractBuilder<T, B> {
+
+        public B uuid(UUID value) {
+            getBuildingInstance().setUuid(value);
+            return getSelf();
+        }
+    }
+
+
+    public static class Builder extends AbstractBuilder<NoopEventMessage, Builder> {
+
+        @Override
+        protected NoopEventMessage.Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        protected NoopEventMessage newBuildingInstance() {
+            return new NoopEventMessage();
+        }
+    }
+}


### PR DESCRIPTION
## WHAT

When /reset is called, the persistence is reset before the event listeners had a chance to handle the DeletedEvents.

Now, we send a NoopEvent after all the DeletedEvents and wait for this NoopEvent. Doing this will ensure every event handler had the chance to do what it needs to.

## WHY

Registry not cleared on /reset

## FURTHER NOTES

Added NoopEventMessage as a way to analyze when the message bus is at what stage.